### PR TITLE
Fix bug to allow detecting multiple wrap directives

### DIFF
--- a/errwrap/errwrap.go
+++ b/errwrap/errwrap.go
@@ -113,16 +113,16 @@ func run(pass *analysis.Pass) (interface{}, error) {
 				}
 			}
 
-			if state.argNum != errIndex {
-				continue
-			}
-
 			if state.verb == 'w' {
 				if anyW {
 					pass.Reportf(call.Pos(), "%s call has more than one error-wrapping directive %%w", state.name)
 					return
 				}
 				anyW = true
+				continue
+			}
+
+			if state.argNum != errIndex {
 				continue
 			}
 

--- a/errwrap/errwrap_test.go
+++ b/errwrap/errwrap_test.go
@@ -9,5 +9,30 @@ import (
 
 func Test(t *testing.T) {
 	testdata := analysistest.TestData()
-	analysistest.Run(t, testdata, errwrap.Analyzer, "a")
+
+	for _, tcase := range []struct {
+		name string
+		dir  string
+	}{
+		{
+			name: "wrap the error with error-wrapping directive",
+			dir:  "a",
+		},
+		{
+			name: "has arguments but no formatting directives",
+			dir:  "b",
+		},
+		{
+			name: "has leftover arguments",
+			dir:  "c",
+		},
+		{
+			name: "too many formatting directives",
+			dir:  "d",
+		},
+	} {
+		t.Run(tcase.name, func(t *testing.T) {
+			analysistest.Run(t, testdata, errwrap.Analyzer, tcase.dir)
+		})
+	}
 }

--- a/errwrap/testdata/src/b/b.go
+++ b/errwrap/testdata/src/b/b.go
@@ -1,0 +1,11 @@
+package b
+
+import (
+	"errors"
+	"fmt"
+)
+
+func foo() error {
+	err := errors.New("bar!")
+	return fmt.Errorf("failed for with error: ", err) // want `Errorf call has arguments but no formatting directives`
+}

--- a/errwrap/testdata/src/c/c.go
+++ b/errwrap/testdata/src/c/c.go
@@ -1,0 +1,11 @@
+package c
+
+import (
+	"errors"
+	"fmt"
+)
+
+func foo() error {
+	err := errors.New("bar!")
+	return fmt.Errorf("failed for %s with error: ", "foo", err) // want `Errorf call needs 1 arg but has 2 args`
+}

--- a/errwrap/testdata/src/d/d.go
+++ b/errwrap/testdata/src/d/d.go
@@ -1,0 +1,13 @@
+package d
+
+import (
+	"errors"
+	"fmt"
+)
+
+func foo() error {
+	err := errors.New("bar!")
+	err2 := errors.New("bar!")
+	return fmt.Errorf("failed with errors %w, %w", err, err2) // want `Errorf call has more than one error-wrapping directive %w`
+}
+


### PR DESCRIPTION
Thanks for this project @fatih, I was writing test cases in an effort to understanding the project and I was unable to replicate the scenario for multiple `%w` directives. This bug fix allows for it.

Happy to hear your thoughts on this