### PR TITLE
Update dependencies to support Go 1.22

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,9 +2,9 @@ module github.com/fatih/errwrap
 
 go 1.20
 
-require golang.org/x/tools v0.6.0
+require golang.org/x/tools v0.17.0
 
 require (
-	golang.org/x/mod v0.8.0 // indirect
-	golang.org/x/sys v0.5.0 // indirect
+	golang.org/x/mod v0.14.0 // indirect
+	golang.org/x/sys v0.16.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,13 @@
 golang.org/x/mod v0.8.0 h1:LUYupSeNrTNCGzR/hVBk2NHZO4hXcVaW1k4Qx7rjPx8=
 golang.org/x/mod v0.8.0/go.mod h1:iBbtSCu2XBx23ZKBPSOrRkjjQPZFPuis4dIYUhu/chs=
+golang.org/x/mod v0.14.0 h1:dGoOF9QVLYng8IHTm7BAyWqCqSheQ5pYWGhzW00YJr0=
+golang.org/x/mod v0.14.0/go.mod h1:hTbmBsO62+eylJbnUtE2MGJUyE7QWk4xUqPFrRgJ+7c=
 golang.org/x/sync v0.1.0 h1:wsuoTGHzEhffawBOhz5CYhcrV4IdKZbEyZjBMuTp12o=
 golang.org/x/sys v0.5.0 h1:MUK/U/4lj1t1oPg0HfuXDN/Z1wv31ZJ/YcPiGccS4DU=
 golang.org/x/sys v0.5.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.16.0 h1:xWw16ngr6ZMtmxDyKyIgsE93KNKz5HKmMa3b8ALHidU=
+golang.org/x/sys v0.16.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 golang.org/x/tools v0.6.0 h1:BOw41kyTf3PuCW1pVQf8+Cyg8pMlkYB1oo9iJ6D/lKM=
 golang.org/x/tools v0.6.0/go.mod h1:Xwgl3UAJ/d3gWutnCtw505GrjyAbvKui8lOU390QaIU=
+golang.org/x/tools v0.17.0 h1:FvmRgNOcs3kOa+T20R1uhfP9F6HgG2mfxDv1vrx1Htc=
+golang.org/x/tools v0.17.0/go.mod h1:xsh6VxdV005rRVaS6SSAf9oiAqljS7UZUacMZ8Bnsps=


### PR DESCRIPTION
## Overview

Building current `main` branch (937dc26654aea0693497738496af3c7fdeea1db8) using Go 1.22rc2 (`golang:1.22rc2-bookworm` Docker image) appears to work, but *running* the linter fails:

```console
$ podman container run -it --rm golang:1.22rc2-bookworm
root@aa3e08d7da78:/go# git clone https://github.com/fatih/errwrap
Cloning into 'errwrap'...
remote: Enumerating objects: 151, done.
remote: Counting objects: 100% (31/31), done.
remote: Compressing objects: 100% (18/18), done.
remote: Total 151 (delta 11), reused 20 (delta 9), pack-reused 120
Receiving objects: 100% (151/151), 33.27 KiB | 442.00 KiB/s, done.
Resolving deltas: 100% (56/56), done.
root@aa3e08d7da78:/go# cd errwrap
root@aa3e08d7da78:/go/errwrap# go install .
go: downloading golang.org/x/tools v0.6.0
go: downloading golang.org/x/sys v0.5.0
go: downloading golang.org/x/mod v0.8.0
root@aa3e08d7da78:/go/errwrap# cd ..
root@aa3e08d7da78:/go# git clone https://github.com/atc0005/check-restart
Cloning into 'check-restart'...
remote: Enumerating objects: 2841, done.
remote: Counting objects: 100% (367/367), done.
remote: Compressing objects: 100% (250/250), done.
remote: Total 2841 (delta 194), reused 104 (delta 103), pack-reused 2474
Receiving objects: 100% (2841/2841), 2.83 MiB | 5.67 MiB/s, done.
Resolving deltas: 100% (1711/1711), done.
root@aa3e08d7da78:/go# cd check-restart
root@aa3e08d7da78:/go/check-restart# errwrap ./...
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
        panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x5b537e]

goroutine 38 [running]:
go/types.(*Checker).handleBailout(0xc0003f4400, 0xc00065bbd0)
        /usr/local/go/src/go/types/check.go:367 +0x88
panic({0x7167c0?, 0x99ea90?})
        /usr/local/go/src/runtime/panic.go:770 +0x132
go/types.(*StdSizes).Sizeof(0x0, {0x7e4328, 0x9a2740})
        /usr/local/go/src/go/types/sizes.go:228 +0x31e
go/types.(*Config).sizeof(...)
        /usr/local/go/src/go/types/sizes.go:333
go/types.representableConst.func1({0x7e4328?, 0x9a2740?})
        /usr/local/go/src/go/types/const.go:76 +0x9e
go/types.representableConst({0x7e6068, 0x997400}, 0xc0003f4400, 0x9a2740, 0xc0006594a0)
        /usr/local/go/src/go/types/const.go:92 +0x192
go/types.(*Checker).representation(0xc0003f4400, 0xc000748d00, 0x9a2740)
        /usr/local/go/src/go/types/const.go:256 +0x65
go/types.(*Checker).implicitTypeAndValue(0xc0003f4400, 0xc000748d00, {0x7e4328, 0x9a2740})
        /usr/local/go/src/go/types/expr.go:375 +0x30d
go/types.(*Checker).assignment(0xc0003f4400, 0xc000748d00, {0x7e4328, 0x9a2740}, {0xc0002202a0, 0x13})
        /usr/local/go/src/go/types/assignments.go:52 +0x2e5
go/types.(*Checker).arguments(0xc0003f4400, 0xc00014d700, 0xc00014c040, {0x0, 0x0, 0x0}, {0x0, 0x0, 0x0}, {0xc00068fa58, ...}, ...)
        /usr/local/go/src/go/types/call.go:654 +0x13dc
go/types.(*Checker).callExpr(0xc0003f4400, 0xc000748c40, 0xc00014d700)
        /usr/local/go/src/go/types/call.go:304 +0x6e9
go/types.(*Checker).exprInternal(0xc0003f4400, 0x0, 0xc000748c40, {0x7e5200, 0xc00014d700}, {0x0, 0x0})
        /usr/local/go/src/go/types/expr.go:1374 +0xf8
go/types.(*Checker).rawExpr(0xc0003f4400, 0x0, 0xc000748c40, {0x7e5200?, 0xc00014d700?}, {0x0?, 0x0?}, 0x0)
        /usr/local/go/src/go/types/expr.go:979 +0x19e
go/types.(*Checker).multiExpr(0xc0003f4400, {0x7e5200, 0xc00014d700}, 0x0)
        /usr/local/go/src/go/types/expr.go:1532 +0x79
go/types.(*Checker).assignVars(0xc0003f4400, {0xc000216950, 0x1, 0x1}, {0xc000216970, 0x1, 0x1})
        /usr/local/go/src/go/types/assignments.go:472 +0xd0
go/types.(*Checker).stmt(0xc0003f4400, 0x0, {0x7e57d0, 0xc00014d740})
        /usr/local/go/src/go/types/stmt.go:476 +0x1628
go/types.(*Checker).stmtList(0xc0003f4400, 0x0, {0xc00045ae80?, 0xc00065b988?, 0x45261e?})
        /usr/local/go/src/go/types/stmt.go:121 +0x85
go/types.(*Checker).funcBody(0xc0003f4400, 0x7e4dc0?, {0xc000470574?, 0xc000620550?}, 0xc0003a0cc0, 0xc0002a18c0, {0x0?, 0x0?})
        /usr/local/go/src/go/types/stmt.go:41 +0x331
go/types.(*Checker).funcDecl.func1()
        /usr/local/go/src/go/types/decl.go:852 +0x3a
go/types.(*Checker).processDelayed(0xc0003f4400, 0x0)
        /usr/local/go/src/go/types/check.go:467 +0x162
go/types.(*Checker).checkFiles(0xc0003f4400, {0xc00068e8a0, 0x3, 0x3})
        /usr/local/go/src/go/types/check.go:411 +0x1cc
go/types.(*Checker).Files(...)
        /usr/local/go/src/go/types/check.go:372
golang.org/x/tools/go/packages.(*loader).loadPackage(0xc00015a000, 0xc0004a81b0)
        /go/pkg/mod/golang.org/x/tools@v0.6.0/go/packages/packages.go:1052 +0xa72
golang.org/x/tools/go/packages.(*loader).loadRecursive.func1()
        /go/pkg/mod/golang.org/x/tools@v0.6.0/go/packages/packages.go:851 +0x1a9
sync.(*Once).doSlow(0x0?, 0x0?)
        /usr/local/go/src/sync/once.go:74 +0xc2
sync.(*Once).Do(...)
        /usr/local/go/src/sync/once.go:65
golang.org/x/tools/go/packages.(*loader).loadRecursive(0x0?, 0x0?)
        /go/pkg/mod/golang.org/x/tools@v0.6.0/go/packages/packages.go:839 +0x4a
golang.org/x/tools/go/packages.(*loader).refine.func2(0x0?)
        /go/pkg/mod/golang.org/x/tools@v0.6.0/go/packages/packages.go:774 +0x26
created by golang.org/x/tools/go/packages.(*loader).refine in goroutine 1
        /go/pkg/mod/golang.org/x/tools@v0.6.0/go/packages/packages.go:773 +0xccf
root@aa3e08d7da78:/go/check-restart# cd ..
root@aa3e08d7da78:/go/errwrap# go get -u ./...
go: downloading golang.org/x/tools v0.17.0
go: downloading golang.org/x/sys v0.16.0
go: downloading golang.org/x/mod v0.14.0
go: downloading golang.org/x/sync v0.6.0
go: upgraded golang.org/x/mod v0.8.0 => v0.14.0
go: upgraded golang.org/x/sys v0.5.0 => v0.16.0
go: upgraded golang.org/x/tools v0.6.0 => v0.17.0
root@aa3e08d7da78:/go/errwrap# go install .
root@aa3e08d7da78:/go/errwrap# cd ..
root@aa3e08d7da78:/go# cd check-restart
root@aa3e08d7da78:/go/check-restart# errwrap ./...
```

## Changes

Update dependencies via `go get -u ./...`:

- `golang.org/x/tools`
  - `v0.6.0` to `v0.17.0`

## References

- https://github.com/atc0005/go-ci/issues/1331