### PR TITLE
fix(docs): correct example in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ func main() {
 
 func foo() error {
         err := errors.New("bar!")
-        return fmt.Errorf("foo failed: %s: %w bar ...", "foo", err)
+        return fmt.Errorf("foo failed: %s: %s bar ...", "foo", err)
 }
 ```
 


### PR DESCRIPTION
The example looks like it is already using the %w param, I think it was intended to look like the "before" on the diff below

Btw, thanks a lot for the series of blog posts, I found them incredibly valuable yesterday!